### PR TITLE
Convert alleleCounter c from samtools to use htslib exclusively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /perl/perltidy.LOG
 /setup.log
 /c/bin/*
+c/src/*.o
+c/tests/*_tests
+c/tests/tests_log

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+1. The usage of a range of years within a copyright statement contained within
+this distribution should be interpreted as being equivalent to a list of years
+including the first and last year specified and all consecutive years between
+them. For example, a copyright statement that reads ‘Copyright (c) 2005, 2007-
+2009, 2011-2012’ should be interpreted as being identical to a statement that
+reads ‘Copyright (c) 2005, 2007, 2008, 2009, 2011, 2012’ and a copyright
+statement that reads ‘Copyright (c) 2005-2012’ should be interpreted as being
+identical to a statement that reads ‘Copyright (c) 2005, 2006, 2007, 2008,
+2009, 2010, 2011, 2012’."
 
 alleleCount
 ===========

--- a/c/Makefile
+++ b/c/Makefile
@@ -6,19 +6,24 @@ CC = gcc -O3
 # -Wall turns on most warnings from compiler
 CFLAGS = -g -Wall
 
+#Location of samtools/htslib libraries
+HTSLOC?=$(HTSLIB)
+
+HTSTMP?=./htslib_tmp
+
 #Define locations of header files
-OPTINC?= -I$(SAMTOOLS)/
-INCLUDES= -I./src/ $(OPTINC) -rdynamic
+OPTINC?=-I$(HTSLOC)/
+INCLUDES= -Isrc/ $(OPTINC) -rdynamic
 
 # define library paths in addition to /usr/lib
 #   if I wanted to include libraries not in /usr/lib I'd specify
 #   their path using -Lpath, something like:
-LFLAGS ?= -L$(SAMTOOLS)
+LFLAGS?= -L$(HTSTMP)
 
 # define any libraries to link into executable:
 #   if I want to link in libraries (libx.so or libx.a) I use the -llibname
 #   option, something like (this will link in libmylib.so and libm.so:
-LIBS= -lbam -lpthread -lz
+LIBS=-lhts -lpthread -lz
 
 # define the C source files
 SRCS=./src/bam_access.c
@@ -35,6 +40,8 @@ TESTS=$(patsubst %.c,%,$(TEST_SRC))
 # Below we are replacing the suffix .c of all words in the macro SRCS
 # with the .o suffix
 #
+MD := mkdir
+
 OBJS = $(SRCS:.c=.o)
 
 #Build target executable
@@ -46,19 +53,18 @@ COUNTER_TARGET=./bin/alleleCounter
 # deleting dependencies appended to the file from 'make depend'
 #
 
-.PHONY: depend clean coverage test
+.PHONY: depend clean coverage test make_htslib_tmp remove_htslib_tmp
 
 .NOTPARALLEL: test
 
-all: $(COUNTER_TARGET) test
+all: clean make_htslib_tmp $(COUNTER_TARGET) test remove_htslib_tmp
 	@echo  Binaries have been compiled.
-
 
 $(COUNTER_TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $(COUNTER_TARGET) $(OBJS) $(LFLAGS) $(LIBS) ./src/alleleCounter.c
 
 #Unit Tests
-test: $(CAVEMAN_TARGET)
+test: $(COUNTER_TARGET)
 test: CFLAGS += $(INCLUDES) $(OBJS) $(LFLAGS) $(LIBS)
 test: $(TESTS)
 	sh ./tests/runtests.sh
@@ -66,6 +72,15 @@ test: $(TESTS)
 #Unit tests with coverage
 coverage: CFLAGS += --coverage
 coverage: test
+
+make_htslib_tmp:
+	$(MD) $(HTSTMP)
+	#Do some magic to ensure we compile ALLELECOUNT with the static libhts.a rather than libhts.so
+	ln -s $(HTSLOC)/libhts.a $(HTSTMP)/libhts.a
+
+remove_htslib_tmp:
+	@echo remove tmp hts location
+	-rm -rf $(HTSTMP)
 
 valgrind:
 	VALGRIND="valgrind --log-file=/tmp/valgrind-%p.log" $(MAKE)

--- a/c/src/alleleCounter.c
+++ b/c/src/alleleCounter.c
@@ -48,7 +48,7 @@ void alleleCounter_print_usage (int exit_code){
 	printf ("Usage: alleleCounter -l loci_file.txt -b sample.bam -o output.txt [-m int] \n\n");
   printf (" -l --loci-file [file]           Path to loci file.\n");
   printf (" -b --hts-file [file]            Path to sample HTS file.\n");
-  printf (" -r --ref-file [file]            Path to reference fasta file.\n");
+  printf (" -r --ref-file [file]            Path to reference fasta index .fai file.\n");
   printf (" -o --output-file [file]         Path write output file.\n\n");
 
 	printf ("Optional\n");

--- a/c/src/bam_access.h
+++ b/c/src/bam_access.h
@@ -23,7 +23,8 @@
 #define _bam_access_h
 
 #include <ctype.h>
-#include "sam.h"
+#include <htslib/hts.h>
+#include <htslib/sam.h>
 
 typedef struct loci_stats{
 	int *base_counts;
@@ -31,19 +32,20 @@ typedef struct loci_stats{
 
 typedef struct file_holder{
 	int beg, end;
-	samfile_t *in;
-	bam_index_t *idx;
+	htsFile *in;
+	hts_idx_t *idx;
 	loci_stats *stats;
+	bam_hdr_t *head;
 } file_holder;
 
 void bam_access_min_base_qual(int qual);
 
 void bam_access_min_map_qual(int qual);
 
-int bam_access_openbam(char *bam_file);
+int bam_access_openhts(char *hts_file, char *ref_file);
 
 loci_stats *bam_access_get_position_base_counts(char *chr, int pos);
 
-void bam_access_closebam();
+void bam_access_closehts();
 
 #endif

--- a/c/tests/bam_access_tests.c
+++ b/c/tests/bam_access_tests.c
@@ -23,13 +23,14 @@
 #include <bam_access.h>
 
 char *test_bam = "../testData/test.bam";
+char *test_ref = "../testData/ref.fa.fai";
 
 char *test_bam_access_get_position_base_counts(){
 	//Check with default settings
 	char *chr = "22";
 	int pos = 16165776;
 	int chk = -1;
-	chk = bam_access_openbam(test_bam);
+	chk = bam_access_openhts(test_bam,test_ref);
 	check(chk == 0,"Error trying to open bam file '%s'.",test_bam);
 	loci_stats *stats = bam_access_get_position_base_counts(chr,pos);
 	mu_assert(stats->base_counts[0]==2,"Check A count 1");
@@ -59,7 +60,7 @@ char *test_bam_access_get_position_base_counts(){
 
 	free(stats->base_counts);
 
-	bam_access_closebam();
+	bam_access_closehts();
 
 	return NULL;
 error:


### PR DESCRIPTION
Fixes #9 
No longer requires samtools for compilation
Supports cram and bam formats 
Will require up to date htslib (>= 1.2)